### PR TITLE
Fixed issue when order isn't deleted in M2 and session check

### DIFF
--- a/Controller/Success/Success.php
+++ b/Controller/Success/Success.php
@@ -106,15 +106,7 @@ class Success extends \Billmate\BillmateCheckout\Controller\FrontCore
                 );
                 
             }
-
-            
-
-			
-
-		}
-		catch (\Exception $e){
-
-
+        } catch (\Exception $e){
             $this->helper->addLog([
                 'note' => 'Could not redirect customer to store order confirmation page',
                 '__FILE__' => __FILE__,
@@ -126,10 +118,8 @@ class Success extends \Billmate\BillmateCheckout\Controller\FrontCore
                 'exception.line' => $e->getLine(),
             ]);
 
-
-            if($this->orderModel->isOrderSent() == 1){
+            if ($this->orderModel->isOrderSent() == 1) {
                 return $this->resultRedirectFactory->create()->setPath('checkout/onepage/success');
-
             }
             $this->helper->clearSession();
 

--- a/Controller/Success/Success.php
+++ b/Controller/Success/Success.php
@@ -133,7 +133,7 @@ class Success extends \Billmate\BillmateCheckout\Controller\FrontCore
             }
             $this->helper->clearSession();
 
-            //Här gör vi en cancel
+            // Execute a cancel transfer
             $values = array(
                 "number" => $requestData['data']['number']
             );
@@ -146,17 +146,10 @@ class Success extends \Billmate\BillmateCheckout\Controller\FrontCore
            return $this->resultRedirectFactory->create()->setPath('billmatecheckout/success/error');
         }
 
-       
-
         if (!$this->helper->getSessionData('bm-inc-id')){
             $orderId = $this->orderModel->setOrderData($orderData)->create();
-
                 if (!$orderId) {
-
-
-
-
-                    //Här gör vi en cancel
+                    // Execute a cancel transfer
                     $values = array(
                         "number" => $requestData['data']['number']
                     );

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -96,15 +96,11 @@ class Order
      */
     public function create($orderId = '')
     {
-
         try {
-
             $this->orderSent = 0;
             if (!$this->getOrderData()) {
-
                 throw new \Exception('The request does not contain order data');
             }
-
 
             if ($orderId == '') {
                 $orderId = $this->dataHelper->getQuote()->getReservedOrderId();
@@ -116,12 +112,7 @@ class Order
             }
 
             $actualCart = $this->createCart($orderId);
-
-
-
-            
         } catch (\Exception $e){
-            
             $this->dataHelper->addLog([
                 'Could not create order',
                 '__FILE__' => __FILE__,
@@ -135,12 +126,8 @@ class Order
             return 0;
         }
 
-        //ifall en order skickas till magento så skickas kunden till
-        
         $orderId = $this->cartManagementInterface->placeOrder($actualCart->getId());
-
         $this->orderSent = 1;
-
         $order = $this->dataHelper->getOrderById($orderId);
 
         if (version_compare($this->metaDataInterface->getVersion(), '2.3.0', '<')) {
@@ -169,6 +156,7 @@ class Order
      * @param $customer
      * Creates qoutes for order.
      * @return mixed
+     * @throws \Exception
      */
     protected function createQuote($orderId, $customer)
     {
@@ -240,8 +228,6 @@ class Order
      */
     protected function createCart($orderId)
     {
-
-
         $billmateShippingAddress = $this->dataHelper->getSessionData('billmate_shipping_address');
         $billmateBillingAddress = $this->dataHelper->getSessionData('billmate_billing_address');
 
@@ -249,7 +235,6 @@ class Order
         $actualQuote = $this->createQuote($orderId, $customer);
 
         $cart = $this->cartRepositoryInterface->get($actualQuote->getId());
-
 
         $cart->setCustomerEmail($customer->getEmail());
         $cart->getBillingAddress()->addData($billmateBillingAddress);
@@ -273,8 +258,6 @@ class Order
      */
     protected function getCustomer($orderData)
     {
-
-
         $store = $this->_storeManager->getStore();
         $websiteId = $this->_storeManager->getStore()->getWebsiteId();
 
@@ -283,9 +266,6 @@ class Order
         $customer->loadByEmail($orderData['email']);
 
         $_password = str_pad($orderData['email'], 10, rand(111,999));
-
-
-        //här blir det fel vid firstname åäö
 
         if (!$customer->getEntityId()){
             $shippingFirstName = '';


### PR DESCRIPTION
Fixed the issue where the order sometimes wasn't deleted from Magento 2 upon error.

Also fixed null-check when there's no session. NOTE: when the customers cookie session is over we will never be able to get their adress. Therefor the customer is now given an actual error after loosing the session instead of a error 500 from the server. The customer is also told to try and place the order again. Cookie session time can be edited in Magento 2 admin under "Stores->Configuration->General->Web->Default Cookie Settings".