### PR TITLE
If session end no order is send to magento

### DIFF
--- a/Model/Order.php
+++ b/Model/Order.php
@@ -102,6 +102,11 @@ class Order
                 $orderId = $this->dataHelper->getQuote()->getReservedOrderId();
             }
 
+            //Checks if session ended.
+            if($orderId == ''){
+                return 0;
+            }
+            
             $exOrder = $this->dataHelper->getOrderByIncrementId($orderId);
             if ($exOrder->getIncrementId()){
                 return;


### PR DESCRIPTION
When the session ends, the order is not sent to Magento. 

It fixes also so no server error appears when a session is ended. 